### PR TITLE
QoL: new encoders/bug fixes

### DIFF
--- a/sparkle/CMakeLists.txt
+++ b/sparkle/CMakeLists.txt
@@ -6,12 +6,15 @@ add_library(sparkle
         lib/target/aarch64/encoder/arith.cpp
         lib/target/aarch64/encoder/atomic.cpp
         lib/target/aarch64/encoder/bitfield.cpp
+        lib/target/aarch64/encoder/bitmanip.cpp
         lib/target/aarch64/encoder/branch.cpp
         lib/target/aarch64/encoder/cmp.cpp
+        lib/target/aarch64/encoder/conditional.cpp
         lib/target/aarch64/encoder/data.cpp
         lib/target/aarch64/encoder/fp.cpp
         lib/target/aarch64/encoder/logical.cpp
         lib/target/aarch64/encoder/memory.cpp
+        lib/target/aarch64/encoder/mul.cpp
         lib/target/aarch64/encoder/shift.cpp
         lib/target/aarch64/encoder/simd.cpp
         lib/target/aarch64/encoder/system.cpp

--- a/sparkle/include/sparkle/target/aarch64/common.hpp
+++ b/sparkle/include/sparkle/target/aarch64/common.hpp
@@ -5,16 +5,6 @@
 namespace sprk::aarch64
 {
     bool encode_logical_imm(uint64_t imm, bool is64bit, uint32_t* N, uint32_t* immr, uint32_t* imms);
-
-    bool is_pattern_repeating(uint64_t imm, int e);
-
-    bool find_s_r(uint64_t pattern, int e, int* s, int* r);
-
-    int ctones(uint64_t value);
-
-    uint64_t reconstruct_imm(int r, int s, int e);
-    
-    int log2(int n);
 }
 
 #define SHIFT_LSL 0

--- a/sparkle/include/sparkle/target/aarch64/encoding/bitmanip.hpp
+++ b/sparkle/include/sparkle/target/aarch64/encoding/bitmanip.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <cstdint>
+
+namespace sprk::aarch64
+{
+    uint32_t encode_rbit(const int rd, const int rn, const bool is64bit);
+
+    uint32_t encode_rev16(const int rd, const int rn, const bool is64bit);
+
+    uint32_t encode_rev32(const int rd, const int rn, const bool is64bit);
+
+    uint32_t encode_rev(const int rd, const int rn, const bool is64bit);
+
+    /* commented out because we couldn't verify if the encoding is legitimate */
+    // uint32_t encode_clz(const int rd, const int rn, const bool is64bit);
+
+    // uint32_t encode_cls(const int rd, const int rn, const bool is64bit);
+
+    // /* for newer ARM revisions */
+    // uint32_t encode_ctz(const int rd, const int rn, const bool is64bit);
+
+    // /* ARMv8.3-A+ extensions */
+    // uint32_t encode_cnt(const int rd, const int rn, const bool is64bit);
+}

--- a/sparkle/include/sparkle/target/aarch64/encoding/conditional.hpp
+++ b/sparkle/include/sparkle/target/aarch64/encoding/conditional.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cstdint>
+
+namespace sprk::aarch64
+{
+    uint32_t encode_csel(const int rd, const int rn, const int rm, const uint32_t cond, const bool is64bit);
+
+    uint32_t encode_csinc(const int rd, const int rn, const int rm, const uint32_t cond, const bool is64bit);
+
+    uint32_t encode_csinv(const int rd, const int rn, const int rm, const uint32_t cond, const bool is64bit);
+    
+    uint32_t encode_csneg(const int rd, const int rn, const int rm, const uint32_t cond, const bool is64bit);
+
+    uint32_t encode_cinc(const int rd, const int rn, const uint32_t cond, const bool is64bit);
+
+    uint32_t encode_cinv(const int rd, const int rn, const uint32_t cond, const bool is64bit);
+
+    uint32_t encode_cneg(const int rd, const int rn, const uint32_t cond, const bool is64bit);
+
+    uint32_t encode_cset(const int rd, const uint32_t cond, const bool is64bit);
+
+    uint32_t encode_csetm(const int rd, const uint32_t cond, const bool is64bit);
+}

--- a/sparkle/include/sparkle/target/aarch64/encoding/fp.hpp
+++ b/sparkle/include/sparkle/target/aarch64/encoding/fp.hpp
@@ -6,7 +6,6 @@ namespace sprk::aarch64
 {
     uint32_t encode_fcmp(int rn, int rm, uint32_t size);
     uint32_t encode_fcmp_zero(int rn, uint32_t size);
-    uint32_t encode_fmov_imm(int rd, float imm, uint32_t size);
     uint32_t encode_fcvt_to_int(int rd, int rn, bool is_signed, bool is64bit, uint32_t rounding, uint32_t size);
     uint32_t encode_fcvt_from_int(int rd, int rn, bool is_signed, bool is64bit, uint32_t size);
     uint32_t encode_fabs(int rd, int rn, uint32_t size);

--- a/sparkle/include/sparkle/target/aarch64/encoding/mul.hpp
+++ b/sparkle/include/sparkle/target/aarch64/encoding/mul.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+namespace sprk::aarch64
+{
+    uint32_t encode_mul(const int rd, const int rn, const int rm, const bool is64bit);
+
+    uint32_t encode_madd(const int rd, const int rn, const int rm, const int ra, const bool is64bit);
+
+    uint32_t encode_msub(const int rd, const int rn, const int rm, const int ra, const bool is64bit);
+
+    uint32_t encode_mneg(const int rd, const int rn, const int rm, const bool is64bit);
+
+    uint32_t encode_smaddl(const int rd, const int rn, const int rm, const int ra);
+
+    uint32_t encode_smsubl(const int rd, const int rn, const int rm, const int ra);
+
+    uint32_t encode_smull(const int rd, const int rn, const int rm);
+
+    uint32_t encode_smnegl(const int rd, const int rn, const int rm);
+
+    uint32_t encode_umaddl(const int rd, const int rn, const int rm, const int ra);
+
+    uint32_t encode_umsubl(const int rd, const int rn, const int rm, const int ra);
+
+    uint32_t encode_umull(const int rd, const int rn, const int rm);
+
+    uint32_t encode_umnegl(const int rd, const int rn, const int rm);
+}

--- a/sparkle/include/sparkle/target/aarch64/encoding/simd.hpp
+++ b/sparkle/include/sparkle/target/aarch64/encoding/simd.hpp
@@ -13,6 +13,4 @@ namespace sprk::aarch64
     uint32_t encode_tbl(int rd, int rn, int rm, uint32_t len, bool is16b);
     uint32_t encode_dup_elem(int rd, int rn, uint32_t index, uint32_t arrangement);
     uint32_t encode_dup_gen(int rd, int rn, uint32_t arrangement);
-    uint32_t encode_ins(int rd, int rn, uint32_t dst_index, uint32_t src_index, uint32_t size);
-    uint32_t encode_umov(int rd, int rn, uint32_t index, uint32_t size);
 }

--- a/sparkle/lib/target/aarch64/common.cpp
+++ b/sparkle/lib/target/aarch64/common.cpp
@@ -5,119 +5,56 @@ namespace sprk::aarch64
 {
     bool encode_logical_imm(uint64_t imm, bool is64bit, uint32_t* N, uint32_t* immr, uint32_t* imms)
     {
-        /* the immediate encoding process for logical operations is complex */
-        /* and involves finding a pattern that can be represented as a bitmask */
-        
-        /* init default values */
         *N = 0;
         *immr = 0;
         *imms = 0;
         
-        /* qcheck for all-zeros or all-ones (not encodable as logical immediates) */
-        if (imm == 0 || (is64bit && imm == 0xFFFFFFFFFFFFFFFF) || (!is64bit && imm == 0xFFFFFFFF))
+        /* special case: all-zeros or all-ones are not encodable */
+        if (imm == 0)
             return false;
-        
-        /* limit check for 32-bit operations (top 32 bits must be all 0 or all 1) */
+            
+        /* replicate the pattern to 64 bits for 32-bit operations */
         if (!is64bit) 
         {
-            imm &= 0xFFFFFFFF; /* mask to 32 bits */
-            imm |= (imm << 32); /* replicate to top 32 bits */
-        }
-        
-        /* find the element size (e) and rotation (r) */
-        int e = 64;
-        while (e >= 2) 
+            imm &= 0xFFFFFFFF;  /* mask to 32 bits */
+            
+            /* check if it's all ones (not encodable) */
+            if (imm == 0xFFFFFFFF)
+                return false;
+                
+            /* replicate to 64 bits for processing */
+            imm |= (imm << 32);
+        } 
+        else 
         {
-            if (is_pattern_repeating(imm, e)) 
-                break;
-            e >>= 1; /* go down every pow2: 64 -> 32 -> 16 etc */
-        }
-        
-        if (e < 2) /* e should be zero */
-            return false; /* not representable as logical immediate */
-        
-        /* find runs of 1s in the base pattern */
-        uint64_t pattern = imm & ((1ULL << e) - 1);
-        int s, r;
-        
-        if (!find_s_r(pattern, e, &s, &r))
-            return false; /* not encodable */
-        
-        /* generate fields for the instruction */
-        *N = (e == 64) ? 1 : 0;
-        *immr = r & ((1 << log2(e)) - 1);
-        *imms = s & ((1 << log2(e)) - 1);
-        
-        return true;
-    }
-
-    /* check if a pattern repeats every 'n' bits */
-    bool is_pattern_repeating(uint64_t imm, int e)
-    {
-        uint64_t pattern = imm & ((1ULL << e) - 1);
-    
-        for (int i = e; i < 64; i += e) 
-        {
-            uint64_t slice = (imm >> i) & ((1ULL << e) - 1);
-            if (slice != pattern)
+            /* for 64-bit, check if all ones (not encodable) */
+            if (imm == 0xFFFFFFFFFFFFFFFF)
                 return false;
         }
         
+        /* find rotation pattern */
+        int rotation = __builtin_ctz(imm & (imm + 1));
+        
+        /* rotate right */
+        uint64_t normalized = rotation == 0 ? imm : 
+            ((imm >> (rotation & 63)) | (imm << (64 - (rotation & 63))));
+        
+        /* find contiguous ones pattern */
+        int leading_zeros = __builtin_clz(normalized);
+        int trailing_ones = __builtin_ctz(~normalized);
+        int size = leading_zeros + trailing_ones;
+        
+        /* verify pattern repeats correctly */
+        uint64_t rotated_check = (size == 0) ? imm : 
+            ((imm >> (size & 63)) | (imm << (64 - (size & 63))));
+        if (rotated_check != imm)
+            return false;
+        
+        /* calculate ARM64 encoding parameters */
+        *N = (size == 64) ? 1 : 0;
+        *immr = (-rotation) & (size - 1);
+        *imms = (-(size << 1) | (trailing_ones - 1)) & 0x3F;
+        
         return true;
-    }
-
-    bool find_s_r(uint64_t pattern, int e, int* s, int* r)
-    {
-        int max_ones = 0;
-        int max_r = 0;
-        
-        for (int r = 0; r < e; r++) 
-        {
-            uint64_t rotated = ((pattern >> r) | (pattern << (e - r))) & ((1ULL << e) - 1);
-
-            int ones = ctones(rotated);
-            if (ones > max_ones) 
-            {
-                max_ones = ones;
-                max_r = r;
-            }
-        }
-        
-        *r = max_r;
-        *s = max_ones - 1;
-        
-        /* check if this pattern is encodable */
-        return (reconstruct_imm(*r, *s, e) == pattern);
-    }
-
-    int ctones(uint64_t value) /* to count trailing 1s in a pattern */
-    {
-        int count = 0;
-    
-        while (value & 1) 
-        {
-            count++;
-            value >>= 1;
-        }
-        
-        return count;
-    }
-
-    /* helper function to reconstruct an immediate from r, s, and e */
-    uint64_t reconstruct_imm(int r, int s, int e)
-    {
-        uint64_t mask = (1ULL << (s + 1)) - 1;
-        return ((mask >> r) | (mask << (e - r))) & ((1ULL << e) - 1);
-    }
-    
-    int log2(int n) /* helper function to compute log2 of a power of 2 */
-    {
-        int result = 0;
-        while (n > 1) 
-        {
-            n >>= 1;
-            result++;
-        }
-        return result;
     }
 }

--- a/sparkle/lib/target/aarch64/encoder/atomic.cpp
+++ b/sparkle/lib/target/aarch64/encoder/atomic.cpp
@@ -70,26 +70,25 @@ namespace sprk::aarch64
 		       rt;                /* source register */
 	}
 
-	/** FIXME */
-	uint32_t encode_cas(const int rs, const int rt, int rn, const uint32_t size, const bool acquire, const bool release)
+	uint32_t encode_cas(const int rs, const int rt, const int rn, const uint32_t size, const bool acquire, const bool release)
 	{
-		/* size: 0=byte, 1=halfword, 2=word, 3=doubleword */
-		constexpr uint32_t L = 1;         /* L=1 for CAS (load-like behavior) */
-		uint32_t A = acquire ? 1 : 0; /* A=1 for acquire semantics */
-		uint32_t R = release ? 1 : 0; /* R=1 for release semantics */
-		constexpr uint32_t o0 = 1;    /* o0=1 for CAS */
+		/* size: 2=word, 3=doubleword only - byte & halfword not supported */
+		/* see: https://developer.arm.com/documentation/ddi0602/2024-12/Base-Instructions/CAS--CASA--CASAL--CASL--Compare-and-swap-word-or-doubleword-in-memory-?lang=en */
+		if (size != 2 && size != 3) 
+			return 0;
+		
+		const uint32_t L = acquire ? 1 : 0;  /* L=1 for acquire semantics */
+		const uint32_t o0 = release ? 1 : 0; /* o0=1 for release semantics */
 
 		return (size << 30) |      /* size field */
-			(0b0010001 << 23) | /* opcode fixed pattern */
-			(L << 22) |         /* L bit */
-			(1 << 21) |         /* fixed bit */
-			(rs << 16) |        /* expected value register */
-			(o0 << 15) |        /* o0 bit for CAS */
-			(A << 14) |         /* A bit for acquire semantics */
-			(R << 13) |         /* R bit for release semantics */
-			(0b11111 << 10) |   /* Rt2=11111 for CAS */
-			(rn << 5) |         /* base register */
-			rt;                 /* target/result register */
+			(0b0010001 << 23) |    /* opcode fixed pattern */
+			(L << 22) |            /* L bit for acquire */
+			(1 << 21) |            /* */
+			(rs << 16) |           /* Rs register (expected value) */
+			(o0 << 15) |           /* o0 bit for release semantics */
+			(0b11111 << 10) |      /* Rt2=11111 for CAS */
+			(rn << 5) |            /* Rn register (memory address) */
+			rt;                    /* Rt register (new/result value) */
 	}
 
 	uint32_t encode_ldadd(const int rs, const int rt, const int rn, const uint32_t size, const bool acquire, const bool release)

--- a/sparkle/lib/target/aarch64/encoder/bitmanip.cpp
+++ b/sparkle/lib/target/aarch64/encoder/bitmanip.cpp
@@ -50,9 +50,9 @@ namespace sprk::aarch64
     
     uint32_t encode_rev(const int rd, const int rn, const bool is64bit)
     {
-        /* REV - Reverse bytes:
-           - For 32-bit (sf=0): reverses bytes in the entire 32-bit word
-           - For 64-bit (sf=1): reverses bytes in the entire 64-bit doubleword (REV64 alias) */
+        /* REV - reverse bytes:
+           - for 32-bit (sf=0): reverses bytes in the entire 32-bit word
+           - for 64-bit (sf=1): reverses bytes in the entire 64-bit doubleword (REV64 alias) */
            
         const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
         const uint32_t opc = is64bit ? 3 : 2;   /* opc = 2 for 32-bit REV, 3 for 64-bit REV */

--- a/sparkle/lib/target/aarch64/encoder/bitmanip.cpp
+++ b/sparkle/lib/target/aarch64/encoder/bitmanip.cpp
@@ -1,0 +1,124 @@
+#include <sparkle/target/aarch64/encoding/bitmanip.hpp>
+
+namespace sprk::aarch64
+{
+    uint32_t encode_rbit(const int rd, const int rn, const bool is64bit)
+    {
+        /* RBIT - reverse bits: reverses the bit order in a register */
+        const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+        constexpr uint32_t opc = 0;             /* opc = 0 for RBIT */
+        
+        return (sf << 31) |        /* size flag */
+               (0b101101011 << 22) | /* fixed pattern */
+               (0b0000000000 << 12) | /* fixed bits */
+               (opc << 10) |       /* operation code */
+               (rn << 5) |         /* source register */
+               rd;                 /* destination register */
+    }
+    
+    uint32_t encode_rev16(const int rd, const int rn, const bool is64bit)
+    {
+        /* REV16 - reverse bytes in 16-bit halfwords */
+        const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+        constexpr uint32_t opc = 1;             /* opc = 1 for REV16 */
+        
+        return (sf << 31) |        /* size flag */
+               (0b101101011 << 22) | /* fixed pattern */
+               (0b0000000000 << 12) | /* fixed bits */
+               (opc << 10) |       /* operation code */
+               (rn << 5) |         /* source register */
+               rd;                 /* destination register */
+    }
+    
+    uint32_t encode_rev32(const int rd, const int rn, const bool is64bit)
+    {
+        /* REV32 - reverse bytes in 32-bit words */
+        /* @note: only valid for 64-bit registers (sf=1) */
+        if (!is64bit)
+            return 0;  /* error: REV32 only valid for 64-bit registers */
+            
+        constexpr uint32_t sf = 1;              /* always 64-bit (1) */
+        constexpr uint32_t opc = 2;             /* opc = 2 for REV32 */
+        
+        return (sf << 31) |        /* size flag */
+               (0b101101011 << 22) | /* fixed pattern */
+               (0b0000000000 << 12) | /* fixed bits */
+               (opc << 10) |       /* operation code */
+               (rn << 5) |         /* source register */
+               rd;                 /* destination register */
+    }
+    
+    uint32_t encode_rev(const int rd, const int rn, const bool is64bit)
+    {
+        /* REV - Reverse bytes:
+           - For 32-bit (sf=0): reverses bytes in the entire 32-bit word
+           - For 64-bit (sf=1): reverses bytes in the entire 64-bit doubleword (REV64 alias) */
+           
+        const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+        const uint32_t opc = is64bit ? 3 : 2;   /* opc = 2 for 32-bit REV, 3 for 64-bit REV */
+        
+        return (sf << 31) |        /* size flag */
+               (0b101101011 << 22) | /* fixed pattern */
+               (0b0000000000 << 12) | /* fixed bits */
+               (opc << 10) |       /* operation code */
+               (rn << 5) |         /* source register */
+               rd;                 /* destination register */
+    }
+    
+    // uint32_t encode_clz(const int rd, const int rn, const bool is64bit)
+    // {
+    //     /* CLZ - count leading zeros: counts the number of leading zeros in a register */
+    //     const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+    //     constexpr uint32_t opcode = 0b100;    /* opcode = 00100 for CLZ */
+        
+    //     return (sf << 31) |        /* size flag */
+    //            (0b101101011000000 << 15) | /* fixed pattern */
+    //            (opcode << 10) |    /* operation code */
+    //            (rn << 5) |         /* source register */
+    //            rd;                 /* destination register */
+    // }
+    
+    // uint32_t encode_cls(const int rd, const int rn, const bool is64bit)
+    // {
+    //     /* CLS - count leading sign bits: counts the number of consecutive bits 
+    //        that match the sign bit, starting from the most significant bit */
+    //     const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+    //     constexpr uint32_t opcode = 0b101;    /* opcode = 00101 for CLS */
+        
+    //     return (sf << 31) |        /* size flag */
+    //            (0b101101011000000 << 15) | /* fixed pattern */
+    //            (opcode << 10) |    /* operation code */
+    //            (rn << 5) |         /* source register */
+    //            rd;                 /* destination register */
+    // }
+    
+    // /* ARM64 also has a count trailing zeros instruction in newer revisions */
+    // uint32_t encode_ctz(const int rd, const int rn, const bool is64bit)
+    // {
+    //     /* CTZ - count trailing zeros: counts the number of trailing zeros in a register */
+    //     /* @note: this is available in ARMv8.5-A and later */
+    //     const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+    //     constexpr uint32_t opcode = 0b110;    /* opcode = 00110 for CTZ */
+        
+    //     return (sf << 31) |        /* size flag */
+    //            (0b101101011000000 << 15) | /* fixed pattern */
+    //            (opcode << 10) |    /* operation code */
+    //            (rn << 5) |         /* source register */
+    //            rd;                 /* destination register */
+    // }
+    
+    // /* helper function for ARMv8.3-A and later extensions: Count Non-Zero Bytes */
+    // uint32_t encode_cnt(const int rd, const int rn, const bool is64bit)
+    // {
+    //     /* CNT - count set bits: counts the number of 1 bits in a register */
+    //     /* @note: this is available in ARMv8.3-A and later */
+    //     const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+    //     constexpr uint32_t opcode = 0b111;    /* opcode = 00111 for CNT */
+        
+    //     return (sf << 31) |        /* size flag */
+    //            (0b101101011000000 << 15) | /* fixed pattern */
+    //            (opcode << 10) |    /* operation code */
+    //            (rn << 5) |         /* source register */
+    //            rd;                 /* destination register */
+    // }
+}

--- a/sparkle/lib/target/aarch64/encoder/conditional.cpp
+++ b/sparkle/lib/target/aarch64/encoder/conditional.cpp
@@ -1,0 +1,135 @@
+#include <sparkle/target/aarch64/encoding/conditional.hpp>
+
+namespace sprk::aarch64
+{
+    uint32_t encode_csel(const int rd, const int rn, const int rm, const uint32_t cond, const bool is64bit)
+    {
+        /* CSEL - conditional select */
+        const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+        constexpr uint32_t op = 0;              /* op = 0 for CSEL */
+        constexpr uint32_t o2 = 0;              /* o2 = 0 for CSEL */
+        
+        if (cond > 15) /* condition code range check */
+            return 0;
+            
+        return (sf << 31) |       /* size flag */
+               (op << 30) |       /* operation type */
+               (0b011010100 << 21) | /* fixed pattern */
+               (rm << 16) |       /* second source register */
+               (cond << 12) |     /* condition code */
+               (0 << 11) |        /* fixed bit */
+               (o2 << 10) |       /* operation variant */
+               (rn << 5) |        /* first source register */
+               rd;                /* destination register */
+    }
+    
+    uint32_t encode_csinc(const int rd, const int rn, const int rm, const uint32_t cond, const bool is64bit)
+    {
+        /* CSINC - conditional select increment */
+        const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+        constexpr uint32_t op = 0;              /* op = 0 for CSINC */
+        constexpr uint32_t o2 = 1;              /* o2 = 1 for CSINC */
+        
+        if (cond > 15) /* condition code range check */
+            return 0;  /* error condition */
+            
+        return (sf << 31) |       /* size flag */
+               (op << 30) |       /* operation type */
+               (0b011010100 << 21) | /* fixed pattern */
+               (rm << 16) |       /* second source register */
+               (cond << 12) |     /* condition code */
+               (0 << 11) |        /* fixed bit */
+               (o2 << 10) |       /* operation variant */
+               (rn << 5) |        /* first source register */
+               rd;                /* destination register */
+    }
+    
+    uint32_t encode_csinv(const int rd, const int rn, const int rm, const uint32_t cond, const bool is64bit)
+    {
+        /* CSINV - conditional select invert */
+        const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+        constexpr uint32_t op = 1;              /* op = 1 for CSINV */
+        constexpr uint32_t o2 = 0;              /* o2 = 0 for CSINV */
+        
+        if (cond > 15) /* Condition code range check */
+            return 0;
+            
+        return (sf << 31) |       /* size flag */
+               (op << 30) |       /* operation type */
+               (0b011010100 << 21) | /* fixed pattern */
+               (rm << 16) |       /* second source register */
+               (cond << 12) |     /* condition code */
+               (0 << 11) |        /* fixed bit */
+               (o2 << 10) |       /* operation variant */
+               (rn << 5) |        /* first source register */
+               rd;                /* festination register */
+    }
+    
+    uint32_t encode_csneg(const int rd, const int rn, const int rm, const uint32_t cond, const bool is64bit)
+    {
+        /* CSNEG - conditional select negate */
+        const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+        constexpr uint32_t op = 1;              /* op = 1 for CSNEG */
+        constexpr uint32_t o2 = 1;              /* o2 = 1 for CSNEG */
+        
+        if (cond > 15) /* condition code range check */
+            return 0;
+            
+        return (sf << 31) |       /* size flag */
+               (op << 30) |       /* operation type */
+               (0b011010100 << 21) | /* fixed pattern */
+               (rm << 16) |       /* second source register */
+               (cond << 12) |     /* condition code */
+               (0 << 11) |        /* fixed bit */
+               (o2 << 10) |       /* operation variant */
+               (rn << 5) |        /* first source register */
+               rd;                /* destination register */
+    }
+    
+    /* helper for the common CINC pseudoinstruction (conditional Increment) */
+    /* CINC is an alias of CSINC with Rm = Rn + inverted condition */
+    uint32_t encode_cinc(const int rd, const int rn, const uint32_t cond, const bool is64bit)
+    {
+        /* CINC Rd, Rn, cond is an alias for CSINC Rd, Rn, Rn, !cond */
+        const uint32_t inv_cond = cond ^ 1; /* invert the condition code's lowest bit */
+        return encode_csinc(rd, rn, rn, inv_cond, is64bit);
+    }
+    
+    /* helper for the common CINV pseudoinstruction (conditional invert) */
+    /* CINV is an alias of CSINV with Rm = Rn + inverted condition */
+    uint32_t encode_cinv(const int rd, const int rn, const uint32_t cond, const bool is64bit)
+    {
+        /* CINV Rd, Rn, cond is an alias for CSINV Rd, Rn, Rn, !cond */
+        const uint32_t inv_cond = cond ^ 1; /* invert the condition code's lowest bit */
+        return encode_csinv(rd, rn, rn, inv_cond, is64bit);
+    }
+    
+    /* helper for the common CNEG pseudoinstruction (conditional negate) */
+    /* CNEG is an alias of CSNEG with Rm = Rn + inverted condition */
+    uint32_t encode_cneg(const int rd, const int rn, const uint32_t cond, const bool is64bit)
+    {
+        /* CNEG Rd, Rn, cond is an alias for CSNEG Rd, Rn, Rn, !cond */
+        const uint32_t inv_cond = cond ^ 1; /* invert the condition code's lowest bit */
+        return encode_csneg(rd, rn, rn, inv_cond, is64bit);
+    }
+    
+    /* helper for the CSET pseudoinstruction (conditional set) */
+    /* CSET is an alias of CSINC with Rn = ZR, Rm = ZR + inverted condition */
+    uint32_t encode_cset(const int rd, const uint32_t cond, const bool is64bit)
+    {
+        /* CSET Rd, cond is an alias for CSINC Rd, ZR, ZR, !cond */
+        const uint32_t inv_cond = cond ^ 1; /* invert the condition code's lowest bit */
+        constexpr uint32_t ZR = 31;         /* zero register */
+        return encode_csinc(rd, ZR, ZR, inv_cond, is64bit);
+    }
+    
+    /* Helper function for the CSETM pseudoinstruction (Conditional Set Minus) */
+    /* CSETM is an alias of CSINV with Rn = ZR, Rm = ZR, and inverted condition */
+    uint32_t encode_csetm(const int rd, const uint32_t cond, const bool is64bit)
+    {
+        /* CSETM Rd, cond is an alias for CSINV Rd, ZR, ZR, !cond */
+        const uint32_t inv_cond = cond ^ 1; /* invert the condition code's lowest bit */
+        constexpr uint32_t ZR = 31;         /* zero register */
+        return encode_csinv(rd, ZR, ZR, inv_cond, is64bit);
+    }
+}

--- a/sparkle/lib/target/aarch64/encoder/fp.cpp
+++ b/sparkle/lib/target/aarch64/encoder/fp.cpp
@@ -67,11 +67,6 @@ namespace sprk::aarch64
 		       (0b000);             /* fixed bits */
 	}
 
-	uint32_t encode_fmov_imm(const int rd, float imm, const uint32_t size)
-	{
-		return 0; /* not implemented! */
-	}
-
 	uint32_t encode_fcvt_to_int(const int rd, int rn, bool is_signed, bool is64bit, uint32_t rounding, uint32_t size)
 	{
 		const uint32_t sf = is64bit ? 1 : 0; /* 64-bit (1) or 32-bit (0) integer result */

--- a/sparkle/lib/target/aarch64/encoder/mul.cpp
+++ b/sparkle/lib/target/aarch64/encoder/mul.cpp
@@ -1,0 +1,156 @@
+#include <sparkle/target/aarch64/encoding/mul.hpp>
+
+namespace sprk::aarch64
+{
+    uint32_t encode_mul(const int rd, const int rn, const int rm, const bool is64bit)
+    {
+        /* MUL is an alias for MADD with RA=XZR */
+        constexpr uint32_t ra = 31; /* zero register (XZR/WZR) */
+        return encode_madd(rd, rn, rm, ra, is64bit);
+    }
+    
+    uint32_t encode_madd(const int rd, const int rn, const int rm, const int ra, const bool is64bit)
+    {
+        /* MADD - Multiply-Add: Rd = Rn * Rm + Ra */
+        const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+        constexpr uint32_t o0 = 0;              /* o0 = 0 for MADD operation */
+        
+        return (sf << 31) |        /* size flag */
+               (0 << 30) |         /* fixed bit */
+               (0b011011 << 24) |  /* fixed pattern */
+               (0 << 23) |         /* fixed bit for non-extended ops */
+               (rm << 16) |        /* second source register (multiplier) */
+               (o0 << 15) |        /* operation type: 0 for MADD */
+               (ra << 10) |        /* third source register (addend) */
+               (rn << 5) |         /* first source register (multiplier) */
+               rd;                 /* destination register */
+    }
+    
+    uint32_t encode_msub(const int rd, const int rn, const int rm, const int ra, const bool is64bit)
+    {
+        /* MSUB - Multiply-Subtract: Rd = Ra - Rn * Rm */
+        const uint32_t sf = is64bit ? 1 : 0;    /* 64-bit (1) or 32-bit (0) */
+        constexpr uint32_t o0 = 1;              /* o0 = 1 for MSUB operation */
+        
+        return (sf << 31) |        /* size flag */
+               (0 << 30) |         /* fixed bit */
+               (0b011011 << 24) |  /* fixed pattern */
+               (0 << 23) |         /* fixed bit for non-extended ops */
+               (rm << 16) |        /* second source register (multiplier) */
+               (o0 << 15) |        /* operation type: 1 for MSUB */
+               (ra << 10) |        /* third source register (subtrahend) */
+               (rn << 5) |         /* first source register (multiplier) */
+               rd;                 /* destination register */
+    }
+    
+    uint32_t encode_mneg(const int rd, const int rn, const int rm, const bool is64bit)
+    {
+        /* MNEG is an alias for MSUB with RA=XZR */
+        constexpr uint32_t ra = 31; /* zero register (XZR/WZR) */
+        return encode_msub(rd, rn, rm, ra, is64bit);
+    }
+    
+    uint32_t encode_smaddl(const int rd, const int rn, const int rm, const int ra)
+    {
+        /* SMADDL - Signed Multiply-Add Long: Rd = Rn * Rm + Ra (sign-extended) */
+        constexpr uint32_t sf = 1;    /* always 64-bit (1) */
+        constexpr uint32_t o0 = 0;    /* o0 = 0 for MADD operation */
+        constexpr uint32_t U = 0;     /* U = 0 for signed operation */
+        
+        return (sf << 31) |        /* size flag */
+            (0 << 30) |         /* fixed bit */
+            (0b011011 << 24) |  /* fixed pattern */
+            (U << 23) |         /* U bit: 0 for signed */
+            (0b01 << 21) |      /* fixed pattern "01" for MULL operations */
+            (rm << 16) |        /* second source register (multiplier) */
+            (o0 << 15) |        /* operation type: 0 for MADD */
+            (ra << 10) |        /* third source register (addend) */
+            (rn << 5) |         /* first source register (multiplier) */
+            rd;                 /* destination register */
+    }
+    
+    uint32_t encode_smsubl(const int rd, const int rn, const int rm, const int ra)
+    {
+        /* SMSUBL - Signed Multiply-Subtract Long: Rd = Ra - Rn * Rm (sign-extended) */
+        constexpr uint32_t sf = 1;    /* always 64-bit (1) */
+        constexpr uint32_t o0 = 1;    /* o0 = 1 for MSUB operation */
+        constexpr uint32_t U = 0;     /* U = 0 for signed operation */
+        
+        return (sf << 31) |        /* size flag */
+               (0 << 30) |         /* fixed bit */
+               (0b011011 << 24) |  /* fixed pattern */
+               (U << 23) |         /* U bit: 0 for signed */
+               (0b01 << 21) |      /* fixed bit for extended ops */
+               (rm << 16) |        /* second source register (multiplier) */
+               (o0 << 15) |        /* operation type: 1 for MSUB */
+               (ra << 10) |        /* third source register (subtrahend) */
+               (rn << 5) |         /* first source register (multiplier) */
+               rd;                 /* destination register */
+    }
+    
+    uint32_t encode_smull(const int rd, const int rn, const int rm)
+    {
+        /* SMULL is an alias for SMADDL with RA=XZR */
+        constexpr uint32_t ra = 31; // Zero register (XZR)
+        return encode_smaddl(rd, rn, rm, ra);
+    }
+    
+    uint32_t encode_smnegl(const int rd, const int rn, const int rm)
+    {
+        /* SMNEGL is an alias for SMSUBL with RA=XZR */
+        constexpr uint32_t ra = 31; /* zero register (XZR/WZR) */
+        return encode_smsubl(rd, rn, rm, ra);
+    }
+    
+    uint32_t encode_umaddl(const int rd, const int rn, const int rm, const int ra)
+    {
+        /* UMADDL - unsigned multiply-add long: Rd = Rn * Rm + Ra (zero-extended) */
+        constexpr uint32_t sf = 1;    /* always 64-bit (1) */
+        constexpr uint32_t o0 = 0;    /* o0 = 0 for MADD operation */
+        constexpr uint32_t U = 1;     /* U = 1 for unsigned operation */
+        
+        return (sf << 31) |        /* size flag */
+               (0 << 30) |         /* fixed bit */
+               (0b011011 << 24) |  /* fixed pattern */
+               (U << 23) |         /* U bit: 1 for unsigned */
+               (0b01 << 21) |      /* fixed bit for extended ops */
+               (rm << 16) |        /* second source register (multiplier) */
+               (o0 << 15) |        /* operation type: 0 for MADD */
+               (ra << 10) |        /* third source register (addend) */
+               (rn << 5) |         /* first source register (multiplier) */
+               rd;                 /* destination register */
+    }
+    
+    uint32_t encode_umsubl(const int rd, const int rn, const int rm, const int ra)
+    {
+        /* UMSUBL - unsigned multiply-subtract long: Rd = Ra - Rn * Rm (zero-extended) */
+        constexpr uint32_t sf = 1;    /* always 64-bit (1) */
+        constexpr uint32_t o0 = 1;    /* o0 = 1 for MSUB operation */
+        constexpr uint32_t U = 1;     /* U = 1 for unsigned operation */
+        
+        return (sf << 31) |        /* size flag */
+               (0 << 30) |         /* fixed bit */
+               (0b011011 << 24) |  /* fixed pattern */
+               (U << 23) |         /* U bit: 1 for unsigned */
+               (0b01 << 21) |         /* fixed bit for extended ops */
+               (rm << 16) |        /* second source register (multiplier) */
+               (o0 << 15) |        /* operation type: 1 for MSUB */
+               (ra << 10) |        /* third source register (subtrahend) */
+               (rn << 5) |         /* first source register (multiplier) */
+               rd;                 /* destination register */
+    }
+    
+    uint32_t encode_umull(const int rd, const int rn, const int rm)
+    {
+        /* UMULL is an alias for UMADDL with RA=XZR */
+        constexpr uint32_t ra = 31; /* zero register (XZR/WZR) */
+        return encode_umaddl(rd, rn, rm, ra);
+    }
+    
+    uint32_t encode_umnegl(const int rd, const int rn, const int rm)
+    {
+        /* UMNEGL is an alias for UMSUBL with RA=XZR */
+        constexpr uint32_t ra = 31; /* zero register (XZR/WZR) */
+        return encode_umsubl(rd, rn, rm, ra);
+    }
+}

--- a/sparkle/lib/target/aarch64/encoder/simd.cpp
+++ b/sparkle/lib/target/aarch64/encoder/simd.cpp
@@ -9,7 +9,7 @@ namespace sprk::aarch64
         uint32_t op = 0;    /* op=0 for MOVI, op=1 for MVNI */
         uint32_t cmode, imm_bits;
         
-        /* Determine Q bit based on arrangement */
+        /* determine Q bit based on arrangement */
         switch (arrangement) 
         {
             case SIMD_8B: /* 8B (8 bytes) */
@@ -30,7 +30,7 @@ namespace sprk::aarch64
             case SIMD_4S: /* 4S (4 words) */
                 Q = 1;
                 break;
-            case SIMD_2D: /* 2D (2 doublewords) - only available for certain immediates */
+            case SIMD_2D: /* 2D (2 doublewords) - only available for certain immediates; may need to handle more cases if this breaks */
                 Q = 1;
                 break;
             default:
@@ -49,17 +49,17 @@ namespace sprk::aarch64
             /* 4H/8H: 16-bit immediate (various patterns) */
             if ((imm & 0xFF) == imm) 
             {
-                cmode = 0x8;            /* 8-bit immediate, zero extended */
+                cmode = 0x8; /* 8-bit immediate, zero extended */
                 imm_bits = imm & 0xFF;
             } 
             else if ((imm & 0xFF00) == imm) 
             {
-                cmode = 0xA;            /* 8-bit immediate, shifted to upper byte */
+                cmode = 0xA; /* 8-bit immediate, shifted to upper byte */
                 imm_bits = (imm >> 8) & 0xFF;
             } 
             else 
             {
-                return 0;               /* Not a supported immediate pattern */
+                return 0; /* Not a supported immediate pattern */
             }
         } 
         else if (arrangement <= SIMD_4S) 
@@ -67,36 +67,36 @@ namespace sprk::aarch64
             /* 2S/4S: 32-bit immediate (various patterns) */
             if ((imm & 0xFF) == imm) 
             {
-                cmode = 0x0;            /* 8-bit immediate, zero extended */
+                cmode = 0x0; /* 8-bit immediate, zero extended */
                 imm_bits = imm & 0xFF;
             } 
             else if ((imm & 0xFF00) == imm) 
             {
-                cmode = 0x2;            /* 8-bit immediate, shifted to byte 1 */
+                cmode = 0x2; /* 8-bit immediate, shifted to byte 1 */
                 imm_bits = (imm >> 8) & 0xFF;
             } 
             else if ((imm & 0xFF0000) == imm) 
             {
-                cmode = 0x4;            /* 8-bit immediate, shifted to byte 2 */
+                cmode = 0x4; /* 8-bit immediate, shifted to byte 2 */
                 imm_bits = (imm >> 16) & 0xFF;
             } 
             else if ((imm & 0xFF000000) == imm) 
             {
-                cmode = 0x6;            /* 8-bit immediate, shifted to byte 3 */
+                cmode = 0x6;/* 8-bit immediate, shifted to byte 3 */
                 imm_bits = (imm >> 24) & 0xFF;
             } 
             else 
             {
-                return 0;               /* Not a supported immediate pattern */
+                return 0; /* not a supported immediate pattern */
             }
         } 
         else if (arrangement == SIMD_2D) 
         {
-            /* 2D: Only special bit patterns are supported */
-            return 0;  /* Complex case, needs a separate encoder */
+            /* 2D: only special bit patterns are supported */
+            return 0;  /* complex case, needs a separate encoder */
         }
         
-        /* Encode the actual instruction */
+        /* encode the actual instruction */
         return (Q << 30) |                /* Q bit for arrangement */
                (op << 29) |               /* Operation: 0 for MOVI */
                (0b0111100000 << 19) |     /* opcode fixed pattern */
@@ -114,7 +114,7 @@ namespace sprk::aarch64
         uint32_t U = 0;     /* U=0 for ADD */
         uint32_t size;      /* 00=8-bit, 01=16-bit, 10=32-bit, 11=64-bit */
         
-        /* Determine Q bit and size based on arrangement */
+        /* determine Q bit and size based on arrangement */
         switch (arrangement) 
         {
             case SIMD_8B: /* 8B (8 bytes) */
@@ -146,13 +146,13 @@ namespace sprk::aarch64
                 size = 3;
                 break;
             default:
-                return 0; /* Error: invalid arrangement */
+                return 0; /* error: invalid arrangement */
         }
         
         return (Q << 30) |                /* Q bit for arrangement */
                (U << 29) |                /* U=0 for ADD */
                (0b01110 << 24) |          /* opcode fixed pattern */
-               (size << 22) |             /* Size field */
+               (size << 22) |             /* size field */
                (1 << 21) |                /* fixed bit */
                (rm << 16) |               /* second source register */
                (0b10000 << 11) |          /* fixed pattern for ADD */
@@ -164,54 +164,54 @@ namespace sprk::aarch64
     uint32_t encode_sub_simd(int rd, int rn, int rm, uint32_t arrangement)
     {
         uint32_t Q = 0;     /* Q=0 for 8B/4H/2S, Q=1 for 16B/8H/4S/2D */
-    uint32_t U = 1;     /* U=1 for SUB */
-    uint32_t size;      /* 00=8-bit, 01=16-bit, 10=32-bit, 11=64-bit */
-    
-    /* determine Q bit and size based on arrangement */
-    switch (arrangement) 
-    {
-        case SIMD_8B: /* 8B (8 bytes) */
-            Q = 0;
-            size = 0;
-            break;
-        case SIMD_16B: /* 16B (16 bytes) */
-            Q = 1;
-            size = 0;
-            break;
-        case SIMD_4H: /* 4H (4 halfwords) */
-            Q = 0;
-            size = 1;
-            break;
-        case SIMD_8H: /* 8H (8 halfwords) */
-            Q = 1;
-            size = 1;
-            break;
-        case SIMD_2S: /* 2S (2 words) */
-            Q = 0;
-            size = 2;
-            break;
-        case SIMD_4S: /* 4S (4 words) */
-            Q = 1;
-            size = 2;
-            break;
-        case SIMD_2D: /* 2D (2 doublewords) */
-            Q = 1;
-            size = 3;
-            break;
-        default:
-            return 0; /* Error: invalid arrangement */
-    }
-    
-    return (Q << 30) |                /* Q bit for arrangement */
-           (U << 29) |                /* U=1 for SUB */
-           (0b01110 << 24) |          /* opcode fixed pattern */
-           (size << 22) |             /* Size field */
-           (1 << 21) |                /* fixed bit */
-           (rm << 16) |               /* second source register */
-           (0b10000 << 11) |          /* fixed pattern for SUB */
-           (1 << 10) |                /* fixed bit */
-           (rn << 5) |                /* first source register */
-           rd;                        /* destination register */
+        uint32_t U = 1;     /* U=1 for SUB */
+        uint32_t size;      /* 00=8-bit, 01=16-bit, 10=32-bit, 11=64-bit */
+        
+        /* determine Q bit and size based on arrangement */
+        switch (arrangement) 
+        {
+            case SIMD_8B: /* 8B (8 bytes) */
+                Q = 0;
+                size = 0;
+                break;
+            case SIMD_16B: /* 16B (16 bytes) */
+                Q = 1;
+                size = 0;
+                break;
+            case SIMD_4H: /* 4H (4 halfwords) */
+                Q = 0;
+                size = 1;
+                break;
+            case SIMD_8H: /* 8H (8 halfwords) */
+                Q = 1;
+                size = 1;
+                break;
+            case SIMD_2S: /* 2S (2 words) */
+                Q = 0;
+                size = 2;
+                break;
+            case SIMD_4S: /* 4S (4 words) */
+                Q = 1;
+                size = 2;
+                break;
+            case SIMD_2D: /* 2D (2 doublewords) */
+                Q = 1;
+                size = 3;
+                break;
+            default:
+                return 0; /* error: invalid arrangement */
+        }
+        
+        return (Q << 30) |                /* Q bit for arrangement */
+            (U << 29) |                /* U=1 for SUB */
+            (0b01110 << 24) |          /* opcode fixed pattern */
+            (size << 22) |             /* size field */
+            (1 << 21) |                /* fixed bit */
+            (rm << 16) |               /* second source register */
+            (0b10000 << 11) |          /* fixed pattern for SUB */
+            (1 << 10) |                /* fixed bit */
+            (rn << 5) |                /* first source register */
+            rd;                        /* destination register */
     }
 
     uint32_t encode_mul_simd(int rd, int rn, int rm, uint32_t arrangement)
@@ -220,7 +220,7 @@ namespace sprk::aarch64
         uint32_t U = 0;     /* U=0 for MUL */
         uint32_t size;      /* 00=8-bit, 01=16-bit, 10=32-bit */
         
-        /* Determine Q bit and size based on arrangement */
+        /* determine Q bit and size based on arrangement */
         switch (arrangement)
         {
             case SIMD_8B: /* 8B (8 bytes) */
@@ -248,7 +248,7 @@ namespace sprk::aarch64
                 size = 2;
                 break;
             default:
-                return 0; /* Error: invalid arrangement for MUL (64-bit not supported) */
+                return 0; /* error: invalid arrangement for MUL (64-bit not supported) */
         }
         
         return (Q << 30) |                /* Q bit for arrangement */
@@ -269,9 +269,9 @@ namespace sprk::aarch64
     {
         uint32_t Q = 0;     /* Q=0 for 8B, Q=1 for 16B */
         uint32_t U = 0;     /* U=0 for AND */
-        uint32_t size = 0;  /* Always 0 for logical operations */
+        uint32_t size = 0;  /* always 0 for logical operations */
         
-        /* Determine Q bit based on arrangement */
+        /* determine Q bit based on arrangement */
         switch (arrangement) 
         {
             case 0: /* 8B (8 bytes) */
@@ -281,7 +281,7 @@ namespace sprk::aarch64
                 Q = 1;
                 break;
             default:
-                return 0; /* Error: invalid arrangement for AND */
+                return 0; /* error: invalid arrangement for AND */
         }
         
         return (Q << 30) |                /* Q bit for arrangement */
@@ -300,9 +300,9 @@ namespace sprk::aarch64
     {
         uint32_t Q = 0;     /* Q=0 for 8B, Q=1 for 16B */
         uint32_t U = 0;     /* U=0 for first logical group */
-        uint32_t size = 2;  /* Always 2 for ORR */
+        uint32_t size = 2;  /* always 2 for ORR */
         
-        /* Determine Q bit based on arrangement */
+        /* determine Q bit based on arrangement */
         switch (arrangement) 
         {
             case SIMD_8B: /* 8B (8 bytes) */
@@ -312,7 +312,7 @@ namespace sprk::aarch64
                 Q = 1;
                 break;
             default:
-                return 0; /* Error: invalid arrangement for ORR */
+                return 0; /* error: invalid arrangement for ORR */
         }
         
         return (Q << 30) |                /* Q bit for arrangement */
@@ -335,7 +335,7 @@ namespace sprk::aarch64
         uint32_t size = 0;             /* size=0 for byte operations */
         
         if (len > 3)
-            return 0; /* Error: invalid length */
+            return 0; /* error: invalid length */
         
         return (Q << 30) |             /* Q bit for vector length */
             (0b001110 << 24) |      /* opcode fixed pattern */
@@ -354,56 +354,57 @@ namespace sprk::aarch64
     uint32_t encode_dup_elem(int rd, int rn, uint32_t index, uint32_t arrangement)
     {
         uint32_t Q = 0;     /* Q=0 for 8B/4H/2S, Q=1 for 16B/8H/4S/2D */
-        uint32_t imm5 = 0;  /* Encoded index and size */
+        uint32_t imm5 = 0;  /* encoded index and size */
         uint32_t op = 0;    /* op=0 for DUP from element */
         
-        /* Determine Q bit and encode imm5 based on arrangement */
+        /* determine Q bit and encode imm5 based on arrangement */
         uint32_t size = 0;
-        switch (arrangement) {
+        switch (arrangement) 
+        {
             case 0: /* 8B (8 bytes) */
                 Q = 0;
                 size = 0;
-                if (index > 15) return 0; /* Error: index out of range */
-                imm5 = (index << 1) | 1;  /* Encode for byte */
+                if (index > 15) return 0; /* error: index out of range */
+                imm5 = (index << 1) | 1;  /* encode for byte */
                 break;
             case 1: /* 16B (16 bytes) */
                 Q = 1;
                 size = 0;
-                if (index > 15) return 0; /* Error: index out of range */
-                imm5 = (index << 1) | 1;  /* Encode for byte */
+                if (index > 15) return 0; /* error: index out of range */
+                imm5 = (index << 1) | 1;  /* encode for byte */
                 break;
             case 2: /* 4H (4 halfwords) */
                 Q = 0;
                 size = 1;
-                if (index > 7) return 0;  /* Error: index out of range */
-                imm5 = (index << 2) | 2;  /* Encode for halfword */
+                if (index > 7) return 0;  /* error: index out of range */
+                imm5 = (index << 2) | 2;  /* encode for halfword */
                 break;
             case 3: /* 8H (8 halfwords) */
                 Q = 1;
                 size = 1;
-                if (index > 7) return 0;  /* Error: index out of range */
-                imm5 = (index << 2) | 2;  /* Encode for halfword */
+                if (index > 7) return 0;  /* error: index out of range */
+                imm5 = (index << 2) | 2;  /* encode for halfword */
                 break;
             case 4: /* 2S (2 words) */
                 Q = 0;
                 size = 2;
-                if (index > 3) return 0;  /* Error: index out of range */
-                imm5 = (index << 3) | 4;  /* Encode for word */
+                if (index > 3) return 0;  /* error: index out of range */
+                imm5 = (index << 3) | 4;  /* encode for word */
                 break;
             case 5: /* 4S (4 words) */
                 Q = 1;
                 size = 2;
-                if (index > 3) return 0;  /* Error: index out of range */
-                imm5 = (index << 3) | 4;  /* Encode for word */
+                if (index > 3) return 0;  /* error: index out of range */
+                imm5 = (index << 3) | 4;  /* encode for word */
                 break;
             case 6: /* 2D (2 doublewords) */
                 Q = 1;
                 size = 3;
-                if (index > 1) return 0;  /* Error: index out of range */
-                imm5 = (index << 4) | 8;  /* Encode for doubleword */
+                if (index > 1) return 0;  /* error: index out of range */
+                imm5 = (index << 4) | 8;  /* encode for doubleword */
                 break;
             default:
-                return 0; /* Error: invalid arrangement */
+                return 0; /* error: invalid arrangement */
     }
     
     return (Q << 30) |             /* Q bit for vector length */
@@ -424,42 +425,42 @@ namespace sprk::aarch64
     uint32_t encode_dup_gen(int rd, int rn, uint32_t arrangement)
     {
         uint32_t Q = 0;     /* Q=0 for 8B/4H/2S, Q=1 for 16B/8H/4S/2D */
-        uint32_t imm5 = 0;  /* Encoded size */
+        uint32_t imm5 = 0;  /* dncoded size */
         uint32_t op = 1;    /* op=1 for DUP from general register */
         
-        /* Determine Q bit and encode imm5 based on arrangement */
+        /* determine Q bit and encode imm5 based on arrangement */
         switch (arrangement) 
         {
             case SIMD_8B: /* 8B (8 bytes) */
                 Q = 0;
-                imm5 = 1;  /* Size for byte */
+                imm5 = 1;  /* size for byte */
                 break;
             case SIMD_16B: /* 16B (16 bytes) */
                 Q = 1;
-                imm5 = 1;  /* Size for byte */
+                imm5 = 1;  /* size for byte */
                 break;
             case SIMD_4H: /* 4H (4 halfwords) */
                 Q = 0;
-                imm5 = 2;  /* Size for halfword */
+                imm5 = 2;  /* size for halfword */
                 break;
             case SIMD_8H: /* 8H (8 halfwords) */
                 Q = 1;
-                imm5 = 2;  /* Size for halfword */
+                imm5 = 2;  /* size for halfword */
                 break;
             case SIMD_2S: /* 2S (2 words) */
                 Q = 0;
-                imm5 = 4;  /* Size for word */
+                imm5 = 4;  /* size for word */
                 break;
             case SIMD_4S: /* 4S (4 words) */
                 Q = 1;
-                imm5 = 4;  /* Size for word */
+                imm5 = 4;  /* size for word */
                 break;
             case SIMD_2D: /* 2D (2 doublewords) */
                 Q = 1;
-                imm5 = 8;  /* Size for doubleword */
+                imm5 = 8;  /* size for doubleword */
                 break;
             default:
-                return 0; /* Error: invalid arrangement */
+                return 0; /* error: invalid arrangement */
         }
         
         return (Q << 30) |             /* Q bit for vector length */
@@ -475,98 +476,5 @@ namespace sprk::aarch64
                (1 << 10) |             /* fixed bit */
                (rn << 5) |             /* source register */
                rd;                     /* destination register */
-    }
-
-    uint32_t encode_ins(int rd, int rn, uint32_t dst_index, uint32_t src_index, uint32_t size)
-    {
-        /* size: 0=byte, 1=halfword, 2=word, 3=doubleword */
-        uint32_t Q = 1;     /* Q=1 for INS (always 128-bit register) */
-        uint32_t op = 0;    /* op=0 for INS element */
-        
-        /* Encode the indices based on element size */
-        uint32_t imm5 = 0;  /* Destination index encoding */
-        uint32_t imm4 = 0;  /* Source index encoding */
-        
-        switch (size) {
-            case SIMD_8B: /* Byte */
-                if (dst_index > 15 || src_index > 15) return 0;
-                imm5 = (dst_index << 1) | 1;
-                imm4 = src_index;
-                break;
-            case SIMD_16B: /* Halfword */
-                if (dst_index > 7 || src_index > 7) return 0;
-                imm5 = (dst_index << 2) | 2;
-                imm4 = src_index << 1;
-                break;
-            case SIMD_4H: /* Word */
-                if (dst_index > 3 || src_index > 3) return 0;
-                imm5 = (dst_index << 3) | 4;
-                imm4 = src_index << 2;
-                break;
-            case SIMD_8H: /* Doubleword */
-                if (dst_index > 1 || src_index > 1) return 0;
-                imm5 = (dst_index << 4) | 8;
-                imm4 = src_index << 3;
-                break;
-            default:
-                return 0; /* Error: invalid size */
-        }
-        
-        return (Q << 30) |             /* Q bit (always 1 for INS) */
-            (op << 29) |            /* op bit (0 for element) */
-            (0b01110 << 24) |       /* opcode fixed pattern */
-            (0 << 22) |             /* fixed bits */
-            (0 << 21) |             /* fixed bit */
-            (imm5 << 16) |          /* destination index encoding */
-            (0 << 15) |             /* fixed bit */
-            (imm4 << 11) |          /* source index encoding */
-            (1 << 10) |             /* fixed bit */
-            (rn << 5) |             /* source register */
-            rd;                     /* destination register */
-    }
-
-    uint32_t encode_umov(int rd, int rn, uint32_t index, uint32_t size)
-    {
-        /* size: 0=byte, 1=halfword, 2=word, 3=doubleword */
-        uint32_t Q = size == 3 ? 1 : 0;  /* Q=1 only for doubleword extract */
-        uint32_t U = 1;                  /* U=1 for UMOV (unsigned extract) */
-        uint32_t imm5 = 0;               /* Index encoding */
-        
-        /* Encode the index based on element size */
-        switch (size) {
-            case 0: /* Byte */
-                if (index > 15) return 0;
-                imm5 = (index << 1) | 1;
-                break;
-            case 1: /* Halfword */
-                if (index > 7) return 0;
-                imm5 = (index << 2) | 2;
-                break;
-            case 2: /* Word */
-                if (index > 3) return 0;
-                imm5 = (index << 3) | 4;
-                break;
-            case 3: /* Doubleword */
-                if (index > 1) return 0;
-                imm5 = (index << 4) | 8;
-                break;
-            default:
-                return 0; /* Error: invalid size */
-        }
-        
-        return (Q << 30) |             /* Q bit */
-            (U << 29) |             /* U bit (1 for unsigned) */
-            (0b01110 << 24) |       /* opcode fixed pattern */
-            (0 << 22) |             /* fixed bits */
-            (0 << 21) |             /* fixed bit */
-            (imm5 << 16) |          /* index encoding */
-            (0 << 15) |             /* fixed bit */
-            (0 << 14) |             /* fixed bit */
-            (1 << 13) |             /* fixed bit */
-            (1 << 12) |             /* fixed bit */
-            (1 << 11) |             /* fixed bit */
-            (1 << 10) |             /* fixed bit */
-            (rn << 5) |             /* source register */
-            rd;                     /* destination general register */
     }
 }


### PR DESCRIPTION
Implemented new encoding features and fixes several aarch64 encoding bugs.


## Fixes

- CAS & its variants (CASL, CAS, CASLA, CASLB)
- SIMD instructions (note: removed due to extra complexities and the instructions being too specialized)

## Features

### Bitmanip

- reverse bit order in a register
- reverse bytes in 16-bit halfwords
- reverse bytes in 32-bit halfwords
- reverse bytes in entire 32-bit word/64-bit double word

### Conditionals

- conditional select
- conditional select increment
- conditional select invert
- conditional select negate
- some helpers & aliases | see implementation details

### Multiplication

- mul
- add multiply
- subtract multiply
- negate multiply
- helper & aliases | see implementation details

----
NOTE: Certain newly implemented instructions are aARM-v8.3-A extensions or newer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced AArch64 support with additional encoding operations for bit manipulation, conditional instructions, and multiplication.

- **Refactor**
	- Streamlined logical immediate and atomic operation encoding for improved clarity and consistency.

- **Tests**
	- Expanded the test suite with new scenarios validating the advanced instruction encoding functionality.

- **Chores**
	- Removed legacy and unsupported encoding routines to simplify the codebase and optimize performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->